### PR TITLE
impl `TryFrom` for the foreign type

### DIFF
--- a/foreign-types-macros/Cargo.toml
+++ b/foreign-types-macros/Cargo.toml
@@ -17,3 +17,4 @@ std = []
 syn = "0.15"
 quote = "0.6"
 proc-macro2 = "0.4"
+select-rustc = "0.1"

--- a/foreign-types-macros/src/lib.rs
+++ b/foreign-types-macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit="128"]
+
 extern crate proc_macro;
 
 use proc_macro::TokenStream;

--- a/foreign-types-shared/Cargo.toml
+++ b/foreign-types-shared/Cargo.toml
@@ -8,3 +8,4 @@ description = "An internal crate used by foreign-types"
 repository = "https://github.com/sfackler/foreign-types"
 
 [dependencies]
+select-rustc = "0.1"

--- a/foreign-types-shared/src/lib.rs
+++ b/foreign-types-shared/src/lib.rs
@@ -52,3 +52,8 @@ pub trait ForeignTypeRef: Sized {
         self as *const _ as *mut _
     }
 }
+
+/// The error type returned when a null pointer been passed to the wrapper.
+#[rustc::since(1.34)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct TryFromForeignTypeError(());

--- a/foreign-types/Cargo.toml
+++ b/foreign-types/Cargo.toml
@@ -13,5 +13,7 @@ default = ["std"]
 std = ["foreign-types-macros/std"]
 
 [dependencies]
+select-rustc = "0.1"
+
 foreign-types-macros = { version = "0.1", path = "../foreign-types-macros" }
 foreign-types-shared = { version = "0.2", path = "../foreign-types-shared" }

--- a/foreign-types/src/lib.rs
+++ b/foreign-types/src/lib.rs
@@ -198,7 +198,7 @@ extern crate std;
 #[doc(hidden)]
 pub use foreign_types_macros::foreign_type_impl;
 #[doc(inline)]
-pub use foreign_types_shared::{ForeignType, ForeignTypeRef, Opaque};
+pub use foreign_types_shared::{ForeignType, ForeignTypeRef, Opaque, TryFromForeignTypeError};
 
 #[doc(hidden)]
 pub mod export {
@@ -208,9 +208,13 @@ pub mod export {
     pub use core::marker::{PhantomData, Send, Sync};
     pub use core::ops::{Deref, DerefMut, Drop};
     pub use core::ptr::NonNull;
+    pub use core::result::Result;
 
     #[cfg(feature = "std")]
     pub use std::borrow::ToOwned;
+
+    #[rustc::since(1.34)]
+    pub use core::convert::TryFrom;
 }
 
 /// A macro to easily define wrappers for foreign types.


### PR DESCRIPTION
Use `TryFrom::try_from` may better than the unsafe `ForeignType::from_ptr`