### PR TITLE
Document the safety preconditions for `ForeignType`

### DIFF
--- a/foreign-types-shared/src/lib.rs
+++ b/foreign-types-shared/src/lib.rs
@@ -14,6 +14,16 @@ use core::mem;
 pub struct Opaque(PhantomData<UnsafeCell<*mut ()>>);
 
 /// A type implemented by wrappers over foreign types.
+///
+/// # Safety
+/// Any implementor of `ForeignType` must guarantee the following:
+/// - `Self::from_ptr(x).to_ptr() == x`
+/// - `Self::from_ptr(x).into_ptr(x) == x`
+/// - `Self::from_ptr(x).deref().as_ptr(x) == x`
+/// - `Self::from_ptr(x).deref_mut().as_ptr(x) == x`
+/// - `Self::from_ptr(x).as_ref().as_ptr(x) == x`
+/// - `Self::from_ptr(x).as_mut().as_ptr(x) == x`
+
 pub unsafe trait ForeignType: Sized {
     /// The raw C type.
     type CType;


### PR DESCRIPTION
I basically just copied your comment from https://github.com/sfackler/foreign-types/commit/3bd4f4fb7eebab09a608ebbd0bbe48b51a20b8a5#r54645666 :)