### PR TITLE
Cast CType pointer to what drop/clone function accepts

### DIFF
--- a/foreign-types-macros/src/build.rs
+++ b/foreign-types-macros/src/build.rs
@@ -130,7 +130,7 @@ fn build_drop_impl(crate_: &Path, input: &ForeignType) -> TokenStream {
             #[inline]
             fn drop(&mut self) {
                 unsafe {
-                    #drop(#crate_::ForeignType::as_ptr(self));
+                    #drop(#crate_::ForeignType::as_ptr(self) as _);
                 }
             }
         }
@@ -222,7 +222,7 @@ fn build_clone_impl(crate_: &Path, input: &ForeignType) -> TokenStream {
             #[inline]
             fn clone(&self) -> #name #ty_generics {
                 unsafe {
-                    let ptr = #clone(#crate_::ForeignType::as_ptr(self));
+                    let ptr = #clone(#crate_::ForeignType::as_ptr(self) as _) as _;
                     #crate_::ForeignType::from_ptr(ptr)
                 }
             }

--- a/foreign-types-macros/src/build.rs
+++ b/foreign-types-macros/src/build.rs
@@ -1,15 +1,18 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Path, Ident};
+use syn::{Ident, Path};
 
-use crate::parse::{Input, ForeignType};
+use crate::parse::{ForeignType, Input};
 
 fn ref_name(input: &ForeignType) -> Ident {
     Ident::new(&format!("{}Ref", input.name), input.name.span())
 }
 
 pub fn build(input: Input) -> TokenStream {
-    let types = input.types.iter().map(|t| build_foreign_type(&input.crate_, t));
+    let types = input
+        .types
+        .iter()
+        .map(|t| build_foreign_type(&input.crate_, t));
     quote! {
         #(#types)*
     }
@@ -45,9 +48,15 @@ fn build_decls(crate_: &Path, input: &ForeignType) -> TokenStream {
     let name = &input.name;
     let generics = &input.generics;
     let ctype = &input.ctype;
-    let phantom_data = input.phantom_data.as_ref().map(|d| quote!(, #crate_::export::PhantomData<#d>));
+    let phantom_data = input
+        .phantom_data
+        .as_ref()
+        .map(|d| quote!(, #crate_::export::PhantomData<#d>));
     let ref_name = ref_name(input);
-    let ref_docs = format!("A borrowed reference to a [`{name}`](struct.{}.html).", name = name);
+    let ref_docs = format!(
+        "A borrowed reference to a [`{name}`](struct.{}.html).",
+        name = name
+    );
 
     quote! {
         #(#attrs)*
@@ -83,7 +92,10 @@ fn build_foreign_impls(crate_: &Path, input: &ForeignType) -> TokenStream {
     let ctype = &input.ctype;
     let ref_name = ref_name(input);
     let (impl_generics, ty_generics, _) = input.generics.split_for_impl();
-    let phantom_data = input.phantom_data.as_ref().map(|_| quote!(, #crate_::export::PhantomData));
+    let phantom_data = input
+        .phantom_data
+        .as_ref()
+        .map(|_| quote!(, #crate_::export::PhantomData));
 
     quote! {
         unsafe impl #impl_generics #crate_::ForeignType for #name #ty_generics {

--- a/foreign-types/tests/test.rs
+++ b/foreign-types/tests/test.rs
@@ -4,7 +4,9 @@ mod foo_sys {
     pub enum FOO {}
 
     pub unsafe extern "C" fn foo_drop(_: *mut FOO) {}
-    pub unsafe extern "C" fn foo_clone(ptr: *mut FOO) -> *mut FOO { ptr }
+    pub unsafe extern "C" fn foo_clone(ptr: *mut FOO) -> *mut FOO {
+        ptr
+    }
 }
 
 foreign_type! {


### PR DESCRIPTION
I'm working on a small PR to update the usage on https://github.com/servo/core-foundation-rs and notice that the FFI functions for drop/clone accept a `c_void` as opposed to the the CType. This PR provides a solution by producing a cast to the accepted type within the function call.

Previously a closure was accepted and [this](https://github.com/servo/core-foundation-rs/blob/6642b11b4c907406779e82382bf94e7ed6d6efd2/core-graphics/src/color_space.rs#L17) is how the pointers are coerced currently. This however doesn't work as `ForeignType` in `parse.rs` only accepts a `ExprPath`.

I had a second PR which accepted a `ExprPath` and `ExprClosure` for drop/clone, but `ExprClosure` requires `syn = { features = ["full"], .. } ` and would also be a breaking change to the `ForeignType` in `parse.rs`.